### PR TITLE
Fix AWK ksecs

### DIFF
--- a/awk/ks.awk
+++ b/awk/ks.awk
@@ -1,6 +1,5 @@
 #!/bin/awk -f
 BEGIN {
-	  KS=(strftime("%H")*3600+strftime("%M")*60+strftime("%S"))/1000; 
-	    printf("It is %s kiloseconds.\n",KS);
-    }
-
+	patsplit(strftime("%T"), t, /[0-9]{2}/)
+	printf "It is %.3f kiloseconds.\n", (t[1]*3600 + t[2]*60 + t[3]) / 1000
+}


### PR DESCRIPTION
Call strftime() once, not thrice, and use patsplit() to parse the time.

One less function call, and the semicolons are not necessary in AWK.